### PR TITLE
add denbug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Create an instance by $address and $options.
   * `$options` is the client connection options. Defaults:
     * `auth`: default ''
     * `db`: default 0
+    * `debug`: default false Whether to save the stack when consumption fails
     * `retry_seconds`: Retry interval after consumption failure
     * `max_attempts`: Maximum number of retries after consumption failure
    

--- a/src/Client.php
+++ b/src/Client.php
@@ -64,6 +64,7 @@ class Client
         'auth'          => '',
         'db'            => 0,
         'prefix'        => '',
+        'debug'        => false,
     ];
 
     /**
@@ -221,7 +222,7 @@ class Client
                             \call_user_func($callback, $package['data']);
                         } catch (\Exception $e) {
                             if (++$package['attempts'] > $this->_options['max_attempts']) {
-                                $package['error'] = (string) $e;
+                                $this->_options['debug'] && $package['error'] = (string) $e;
                                 $this->fail($package);
                             } else {
                                 $this->retry($package);
@@ -229,7 +230,7 @@ class Client
                             echo $e;
                         } catch (\Error $e) {
                             if (++$package['attempts'] > $this->_options['max_attempts']) {
-                                $package['error'] = (string) $e;
+                                $this->_options['debug'] && $package['error'] = (string) $e;
                                 $this->fail($package);
                             } else {
                                 $this->retry($package);


### PR DESCRIPTION
### 增加 配置项 `debug` 默认 false

这样他的依赖基础库[webman/redis-queue](https://github.com/webman-php/redis-queue)或其他库 可以选择性的是否保存错误堆栈信息到redis 从而导致 redis撑爆

#10 如何优雅的抛出异常？

