### PR TITLE
feat(exception): add UnretryableException

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -241,6 +241,11 @@ class Client
                         $callback = $this->_subscribeQueues[$redis_key];
                         try {
                             \call_user_func($callback, $package['data']);
+                        } catch (UnretryableException $e) {
+                            $this->log((string)$e);
+                            $package['max_attempts'] = $this->_options['max_attempts'];
+                            $package['error'] = $e->getMessage();
+                            $this->fail($package);
                         } catch (\Throwable $e) {
                             $this->log((string)$e);
                             $package['max_attempts'] = $this->_options['max_attempts'];

--- a/src/UnretryableException.php
+++ b/src/UnretryableException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Workerman\RedisQueue;
+
+class UnretryableException extends \Exception
+{}


### PR DESCRIPTION
I've been using this package in production for about a year now, and I encountered a need for a custom exception to handle specific error cases more effectively.

In particular, one use case involves a third-party service that occasionally returns a 403 error. When this happens, I want to avoid retrying the job, as subsequent attempts would also likely result in the same 403 response. Previously, I had to catch the exception manually with try-catch blocks and mark the job as failed in our logs, which wasn't ideal and led to less clean code.

To resolve this, I implemented a solution in our system where a specific type of exception prevents retry attempts automatically. This approach has significantly streamlined our code and improved error handling.

I’ve customized this further in our environment, and if this PR is accepted, I’d be happy to contribute additional enhancements over time.