### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ Create an instance by $address and $options.
 -------------------------------------------------------
 
 <a name="send"></a>
-### send(String $queue, Mixed $data, [int $dely=0])
+### send(String $queue, Mixed $data, [int $delay=0])
 
 Send a message to a queue
 
 * `$queue` is the queue to publish to, `String`
 * `$data` is the message to publish, `Mixed`
-* `$dely` is delay seconds for delayed consumption, `Int`
+* `$delay` is delay seconds for delayed consumption, `Int`
   
 -------------------------------------------------------
 


### PR DESCRIPTION
This pull request includes a minor documentation fix in the `README.md` file. The change corrects a typo in the parameter name from `$dely` to `$delay` in the description of the `send` method.